### PR TITLE
config.ini compatibility and modularity updates

### DIFF
--- a/cogs/music_controller.py
+++ b/cogs/music_controller.py
@@ -19,7 +19,7 @@ class MusicController(commands.Cog):
         self.bot = bot
 
     @cog_ext.cog_slash(name="test",
-                       guild_ids=[GUILD_ID],
+                       guild_ids=GUILD_ID,
                        )
     async def _test(self, ctx: SlashContext):
         embed = discord.Embed(title="embed test")
@@ -43,7 +43,7 @@ class MusicController(commands.Cog):
         await ctx.send(content=f"{status}", hidden=True)
 
     @cog_ext.cog_slash(name="youtube",
-                       guild_ids=[GUILD_ID],
+                       guild_ids=GUILD_ID,
                        description='Add a youtube video to the queue.',
                        options=[
                            create_option(
@@ -57,20 +57,20 @@ class MusicController(commands.Cog):
         await self.process_slash_command(ctx, src.parser.message)
 
     @cog_ext.cog_slash(name="prev",
-                       guild_ids=[GUILD_ID],
+                       guild_ids=GUILD_ID,
                        description='Goes to the previous song.')
     async def _prev(self, ctx: SlashContext):
         await self.process_slash_command(ctx, src.parser.player_prev)
 
     @cog_ext.cog_slash(name="next",
-                       guild_ids=[GUILD_ID],
+                       guild_ids=GUILD_ID,
                        description='Goes to the next song.')
     async def _next(self, ctx: SlashContext):
         await self.process_slash_command(ctx, src.parser.player_next)
 
     @cog_ext.cog_slash(name="play",
                        description='Plays or resumes a song.',
-                       guild_ids=[GUILD_ID],
+                       guild_ids=GUILD_ID,
                        options=[
                            create_option(
                                name="song_name_or_link",
@@ -88,7 +88,7 @@ class MusicController(commands.Cog):
 
     @cog_ext.cog_slash(name="pause",
                        description='Pauses actively playing song',
-                       guild_ids=[GUILD_ID],
+                       guild_ids=GUILD_ID,
                        )
     async def _pause(self, ctx: SlashContext):
         await self.process_slash_command(ctx, src.parser.pause_player)

--- a/config.py
+++ b/config.py
@@ -3,64 +3,67 @@ import shutil
 import configparser
 import glob
 
-# Config specific variables
-__config = configparser.ConfigParser()
-_FFMPEG_ERROR_NOT_FOUND = "ffmpeg was not found on this system. If installed, provide the path in the config."
-
-
-# Config specific functions
-def make_config():
+def gen_config() -> configparser.ConfigParser:
     """Generates a default configeration file."""
-    __config.add_section('Default')
-    __config['Default']['TOKEN'] = ''
-    __config['Default']['FFMPEG_PATH'] = ''
-    __config['Default']["GUILD_ID"] = ''
-    __config.add_section('Cache')
-    __config['Cache']['DOWNLOAD_PATH'] = os.path.join('cache', 'youtube')
-    __config['Cache']['TEMP_PATH'] = os.path.join('cache', 'temp')
-    __config['Cache']['MAX_CACHESIZE'] = '0'
-    __config['Cache']['MAX_FILESIZE'] = '100000000'
+    generated_config = configparser.ConfigParser()
+
+    # [Default]
+    generated_config.add_section('Default')
+    generated_config['Default']['TOKEN'] = ''
+    generated_config['Default']['FFMPEG_PATH'] = ''
+    generated_config['Default']["GUILD_ID"] = ''
+
+    # [Cache]
+    generated_config.add_section('Cache')
+    generated_config['Cache']['DOWNLOAD_PATH'] = os.path.join('cache', 'youtube')
+    generated_config['Cache']['TEMP_PATH'] = os.path.join('cache', 'temp')
+    generated_config['Cache']['MAX_CACHESIZE'] = '0'
+    generated_config['Cache']['MAX_FILESIZE'] = '100000000'
+
+    return generated_config
+
+# config specific functions
+def write_config(config: configparser.ConfigParser) -> None:
     with open("config.ini", 'w') as f:
-        __config.write(f)
+        config.write(f)
 
-
-def set_token():
-    """Sets the token dynamically."""
-    config_token = __config['Default']['TOKEN']
+def set_token(config: configparser.ConfigParser):
+    """sets the token dynamically"""
+    config_token = config['Default']['TOKEN']
     envvar_token = os.environ.get('DiscordToken_mbox')
+    
     if config_token:
         return config_token
     elif envvar_token:
         return envvar_token
     else:
-        return input("No token in config file or in enviroment variable \'DiscordToken_mbox\'. Please generate a token and enter it below. ")
+       return input("No token in config file or in enviroment variable \'DiscordToken_mbox\'. Please generate a token and enter it below.")
 
-
-def set_ffmpeg_path():
-    """Sets the ffmpeg_path dynamically."""
+def set_ffmpeg_path(config: configparser.ConfigParser):
+    """sets the ffmpeg_path dynamically"""
     try:
-        if __config['Default']['FFMPEG_PATH']:
-            return __config['Default']['FFMPEG_PATH']
+        if config['Default']['FFMPEG_PATH']:
+            return config['Default']['FFMPEG_PATH']
         elif shutil.which('ffmpeg'):
             return 'ffmpeg'
         elif glob.glob('ffmpeg*'):
             return get_ffmpeg_path(glob.glob('ffmpeg*'))
     except:
-        raise ProcessLookupError(_FFMPEG_ERROR_NOT_FOUND)
+        FFMPEG_ERROR_NOT_FOUND = "ffmpeg was not found on this system. If installed, provide the path in the config."
+        raise ProcessLookupError(FFMPEG_ERROR_NOT_FOUND)
 
-
-def set_guild_id():
-    config_guild_id = __config['Default']['GUILD_ID']
+def set_guild_id(config: configparser.ConfigParser) -> list[int]:
+    """sets the ffmpeg_path dynamically"""
+    config_guild_id = config['Default']['GUILD_ID']
     envar_guild_id = os.getenv("DISCORD_GUILD", "")
     if config_guild_id:
-        return int(config_guild_id)
+        return [int(config_guild_id)]
     elif envar_guild_id:
-        return int(envar_guild_id)
+        return [int(envar_guild_id)]
     else:
-        return int(input("Please set your guild-id "))
+        return None
 
-
-def get_ffmpeg_path(ffmpeg_paths: str):
+def get_ffmpeg_path(ffmpeg_paths: str) -> str:
     for path in ffmpeg_paths:
         if os.path.isdir(path):
             try:
@@ -78,20 +81,41 @@ def get_ffmpeg_path(ffmpeg_paths: str):
             except:
                 raise FileNotFoundError
 
-
-# Create and set the config
+# generate and set the config
+default_config = gen_config()
 if not os.path.isfile('config.ini'):
-    make_config()
-__config.read('config.ini')
+    write_config(default_config)
+else:
+    disk_config = configparser.ConfigParser()
+    disk_config.read('config.ini')
+
+    # find missing fields in disk config add them if missing
+    reference_dict: dict = default_config._sections
+    disk_dict: dict = disk_config._sections
+
+    section: str
+    section_dict: dict
+    for section, section_dict in reference_dict.items():
+        # check disk dictionary has the section
+        if not disk_dict[section]:
+            disk_config.add_section(section)
+
+        key: str
+        value: str
+        for key, value in section_dict.items():
+            # check disk dictionary have a key in the section
+            if key not in disk_dict[section]: 
+                disk_config[section][key] = default_config[section][key]
+                write_config(disk_config) # write changes to disk
 
 ###### USER CONFIG ######
-TOKEN = set_token()
-FFMPEG_PATH = set_ffmpeg_path()
-GUILD_ID = set_guild_id()
-
+TOKEN = set_token(disk_config)
+FFMPEG_PATH = set_ffmpeg_path(disk_config)
+GUILD_ID= set_guild_id(disk_config)
 
 # TODO: Sanitize and check if values are valid
-DOWNLOAD_PATH = __config['Cache']['DOWNLOAD_PATH']
-TEMP_PATH = __config['Cache']['TEMP_PATH']
-MAX_CACHESIZE = int(__config['Cache']['MAX_CACHESIZE'])
-MAX_FILESIZE = int(__config['Cache']['MAX_FILESIZE'])
+DOWNLOAD_PATH = disk_config['Cache']['DOWNLOAD_PATH']
+TEMP_PATH = disk_config['Cache']['TEMP_PATH']
+MAX_CACHESIZE = int(disk_config['Cache']['MAX_CACHESIZE'])
+MAX_FILESIZE = int(disk_config['Cache']['MAX_FILESIZE'])
+


### PR DESCRIPTION
Changes

- Function in config.py return objects instead of changing config.py variables
- renamed make_config to gen_config to more accurately describe the function
- Removed '_' (underscore) notation as the __config variable is encapsulated in gen_config()
- added type definitions in functions
- config.py will add missing fields that it could not find in config.ini
- removed program input() for guild_id as it messes up the test suite and it is a developer variable (not required to run the bot)
- config.py only supports one guild_id (instead of a list) to simplify config.ini (since developers normally only need to input one guild id anyway)