### PR TITLE
Hotfix: Made config parser run regardless if config exists

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import configparser
 import glob
+from typing import List
 
 def gen_config() -> configparser.ConfigParser:
     """Generates a default configeration file."""
@@ -52,7 +53,7 @@ def set_ffmpeg_path(config: configparser.ConfigParser):
         FFMPEG_ERROR_NOT_FOUND = "ffmpeg was not found on this system. If installed, provide the path in the config."
         raise ProcessLookupError(FFMPEG_ERROR_NOT_FOUND)
 
-def set_guild_id(config: configparser.ConfigParser) -> list[int]:
+def set_guild_id(config: configparser.ConfigParser) -> List[int]:
     """sets the ffmpeg_path dynamically"""
     config_guild_id = config['Default']['GUILD_ID']
     envar_guild_id = os.getenv("DISCORD_GUILD", "")

--- a/config.py
+++ b/config.py
@@ -85,28 +85,28 @@ def get_ffmpeg_path(ffmpeg_paths: str) -> str:
 default_config = gen_config()
 if not os.path.isfile('config.ini'):
     write_config(default_config)
-else:
-    disk_config = configparser.ConfigParser()
-    disk_config.read('config.ini')
 
-    # find missing fields in disk config add them if missing
-    reference_dict: dict = default_config._sections
-    disk_dict: dict = disk_config._sections
+disk_config = configparser.ConfigParser()
+disk_config.read('config.ini')
 
-    section: str
-    section_dict: dict
-    for section, section_dict in reference_dict.items():
-        # check disk dictionary has the section
-        if not disk_dict[section]:
-            disk_config.add_section(section)
+# find missing fields in disk config add them if missing
+reference_dict: dict = default_config._sections
+disk_dict: dict = disk_config._sections
 
-        key: str
-        value: str
-        for key, value in section_dict.items():
-            # check disk dictionary have a key in the section
-            if key not in disk_dict[section]: 
-                disk_config[section][key] = default_config[section][key]
-                write_config(disk_config) # write changes to disk
+section: str
+section_dict: dict
+for section, section_dict in reference_dict.items():
+    # check disk dictionary has the section
+    if not disk_dict[section]:
+        disk_config.add_section(section)
+
+    key: str
+    value: str
+    for key, value in section_dict.items():
+        # check disk dictionary have a key in the section
+        if key not in disk_dict[section]: 
+            disk_config[section][key] = default_config[section][key]
+            write_config(disk_config) # write changes to disk
 
 ###### USER CONFIG ######
 TOKEN = set_token(disk_config)

--- a/src/music/player.py
+++ b/src/music/player.py
@@ -1,4 +1,5 @@
 import threading
+from typing import Dict
 from discord.channel import TextChannel, VoiceChannel
 from discord.client import Client
 from discord.message import Message
@@ -424,7 +425,7 @@ class Player:
         self.queue_message    = await command_channel.send(embed=self.queue_embed)
         self.player_message   = await command_channel.send(embed=self.player_embed)
 
-    def metadata_youtube_dl(self, info: dict) -> dict[str,str]:
+    def metadata_youtube_dl(self, info: dict) -> Dict[str,str]:
         """Parses youtube_dl dictionary to standard mbox naming format.
 
         Args:


### PR DESCRIPTION
This hotfix will load the config.ini regardless if config.ini exists. This fixes error `disk_config does not exist.`
This PR also contains fixes to support versions < python 3.8 by using typing library. [ref](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html#:~:text=%23%20In%20Python%203.8%20and%20earlier%2C%20the%20name%20of%20the%20collection%20type%20is%0A%23%20capitalized%2C%20and%20the%20type%20is%20imported%20from%20%27typing%27%0Ax%3A%20List%5Bint%5D%20%3D%20%5B1%5D%0Ax%3A%20Set%5Bint%5D%20%3D%20%7B6%2C%207%7D)