### PR TITLE
Added dict_factory to asdict call

### DIFF
--- a/src/element/database.py
+++ b/src/element/database.py
@@ -96,7 +96,12 @@ class DynamoDB(Database):
             dict: responce from AWS
         """
         self.cache_record(record)
-        record_dict = asdict(record)
+        record_dict = asdict(
+            record,
+            dict_factory=lambda data: dict(
+                x for x in data if x[1] is not None
+            ),
+        )
         record_dict["application_id"] = self.application_id
         response = self.table.put_item(Item=record_dict)
         return response


### PR DESCRIPTION
**Description**
Applies https://stackoverflow.com/questions/59481989/dict-from-nested-dataclasses solution to our asdict call for our dataclass "Record". This prevents dynamodb records from showing null: 
![image](https://user-images.githubusercontent.com/16157348/124539742-0ae91580-ddec-11eb-95d9-c535baf484ec.png)

**Changes include**

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Refactor (non-breaking/breaking change that refactor the previous code base)

**Todos**

- [ ] Updated and Passed Tests
- [ ] Passed Quality Checks
- [ ] Updated  Documentation

**Screenshots**

Add any screenshots as needed

**Other comments**
